### PR TITLE
Add daily interests in schedule table

### DIFF
--- a/index.html
+++ b/index.html
@@ -219,6 +219,7 @@
                     month,
                     date: currentDate,
                     daysInPeriod,
+                    dailyInterest: formatCurrency((remainingPrincipalCents * dailyRate) / 100),
                     monthlyPayment: formatCurrency(monthlyPaymentCents / 100),
                     interestPayment: formatCurrency(interestPaymentCents / 100),
                     principalPayment: formatCurrency(principalPaymentCents / 100),
@@ -423,6 +424,7 @@
                             <th>Rata</th>
                             <th>Odsetki</th>
                             <th>Kapitał</th>
+                            <th>Odsetki dzienne</th>
                             <th>Pozostało do spłaty</th>
                         </tr>
                     </thead>
@@ -443,6 +445,7 @@
                         <td>${item.monthlyPayment} zł</td>
                         <td>${item.interestPayment} zł</td>
                         <td>${item.principalPayment} zł</td>
+                        <td>${item.dailyInterest} zł</td>
                         <td>${item.remainingPrincipal} zł</td>
                     </tr>
                 `;


### PR DESCRIPTION
Update `index.html` to calculate and display daily interest in the loan schedule table.

* Add `dailyInterest` field to the schedule array in `calculateLoanSchedule` function.
* Add a new column for daily interest in the schedule table header.
* Display daily interest in the schedule table rows.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/olaq/scaling-pancake/pull/2?shareId=58cd6a17-47da-4a55-b529-d2fae07c3c88).